### PR TITLE
Userspace time measurement

### DIFF
--- a/System/GetRUsage.hsc
+++ b/System/GetRUsage.hsc
@@ -1,0 +1,41 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module System.GetRUsage (getUserspaceCPUTime) where
+
+#include "HsBaseConfig.h"
+
+import Foreign
+import Foreign.C
+
+#if !defined(mingw32_HOST_OS) && !defined(irix_HOST_OS)
+# if HAVE_SYS_RESOURCE_H
+#  include <sys/resource.h>
+# endif
+
+realToInteger :: Real a => a -> Integer
+realToInteger ct = round (realToFrac ct :: Double)
+#endif
+
+-- | Returns the userspace portion of the execution time of the current
+-- program, in picoseconds.
+--
+-- This might fall back to total time if the system is not compliant to
+-- POSIX-1.2001, SVr4 or 4.3BSD.
+getUserspaceCPUTime :: IO Integer
+#if !defined(mingw32_HOST_OS) && !defined(cygwin32_HOST_OS) \
+    && defined(HAVE_GETRUSAGE) && ! irix_HOST_OS && ! solaris2_HOST_OS
+
+getUserspaceCPUTime =
+  allocaBytes (#const sizeof(struct rusage)) $ \p_rusage -> do
+    throwErrnoIfMinus1_ "getrusage" $ getrusage (#const RUSAGE_SELF) p_rusage
+
+    let ru_utime = (#ptr struct rusage, ru_utime) p_rusage
+    u_sec  <- (#peek struct timeval,tv_sec)  ru_utime :: IO CTime
+    u_usec <- (#peek struct timeval,tv_usec) ru_utime :: IO CSUSeconds
+    return ((realToInteger u_sec * 1000000 + realToInteger u_usec) * 1000000)
+
+foreign import ccall unsafe "HsBase.h getrusage"
+    getrusage :: CInt -> Ptr () -> IO CInt
+
+#else // as a fallback
+getUserspaceCPUTime = getCPUTime
+#endif

--- a/timeit.cabal
+++ b/timeit.cabal
@@ -33,6 +33,8 @@ Library
   Exposed-Modules:      System.TimeIt
   Build-Depends:        base >= 3 && < 5
 
+  Other-Modules:        System.GetRUsage
+
   if impl(ghc < 8.0)
     Build-Depends:      transformers >= 0.2 && < 0.6
 

--- a/timeit.cabal
+++ b/timeit.cabal
@@ -1,5 +1,5 @@
 Name:               timeit
-Version:            2.0
+Version:            2.1
 
 Homepage:           https://github.com/merijn/timeit
 Bug-Reports:        https://github.com/merijn/timeit/issues


### PR DESCRIPTION
I'm only replicating the behavior of `timeItT`. Replicating other functions seems unreasonable (looks like it's not a particularly widely needed feature, so I'm not sure cluttering the API is worth it), and changing the API to unify total CPU time vs userspace time (and maybe vs kernel time) is probably not worthy for the same reasons (compatibility seems to be more important than this feature).